### PR TITLE
Support channel posting

### DIFF
--- a/apps/next/components/create-post/index.tsx
+++ b/apps/next/components/create-post/index.tsx
@@ -519,7 +519,6 @@ function SelectChannel() {
   const { channel, setChannel } = useCreatePost();
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
-  const [loading, setLoading] = useState(false);
 
   // TODO: Get channels from API
   const channels = [
@@ -532,18 +531,9 @@ function SelectChannel() {
     { name: 'memes', displayName: '/memes', members: '372K' },
   ];
 
-  // const { } = useCreatePost()
-
   const filteredChannels = channels.filter(channel =>
     channel.name.toLowerCase().includes(searchTerm.toLowerCase())
   );
-
-  const handleSetChannel = async () => {
-    setLoading(true)
-    const data = await api.getCast(value)
-    setOpen(false)
-    setLoading(false)
-  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
This PR introduces basic support for a new tooltip button with a fixed set of channels. It also updates the tooltip button to support a filled state to indicate to the user when a channel has been set before posting. 

![CleanShot 2024-11-20 at 21 38 07](https://github.com/user-attachments/assets/3c9f5a98-6133-4680-9db2-5d3db80a4f88)


