### PR TITLE
coins feed

### DIFF
--- a/apps/next/lib/api/index.ts
+++ b/apps/next/lib/api/index.ts
@@ -92,4 +92,10 @@ export const api = {
     );
     return response.data;
   },
+  getCoinsPosts: async (tokenAddress: string) => {
+    const response = await apiClient.request<GetCastsResponse>(
+      `/feed/${tokenAddress}/coins`
+    );
+    return response.data;
+  },
 };

--- a/packages/api/src/routes/feed.ts
+++ b/packages/api/src/routes/feed.ts
@@ -49,3 +49,24 @@ export const feedRoutes = createElysia({ prefix: '/feed' })
       }),
     }
   )
+  .get(
+    '/:tokenAddress/coins',
+    async ({ params }) => {
+      const cached = await redis.get(`coins:${params.tokenAddress}`)
+      if (cached) {
+        return JSON.parse(cached)
+      }
+
+      const response = await neynar.getUserCasts(TOKEN_CONFIG[params.tokenAddress].fid)
+      const filteredCasts = {
+        casts: response.casts.filter(cast => cast.text.includes('@tokenbot'))
+      }
+      await redis.set(`coins:${params.tokenAddress}`, JSON.stringify(filteredCasts), 'EX', 30)
+      return filteredCasts
+    },
+    {
+      params: t.Object({
+        tokenAddress: t.String(),
+      }),
+    }
+  )


### PR DESCRIPTION
Initial attempt at adding clanker filtered feed. @Slokh pls review. 

This pull request updates the PostFeed component and its associated API with the following changes:
	1.	PostFeed Component:
	▪	Added a new "coins" tab to the PostFeed component in apps/next/components/post-feed/index.tsx.
	▪	Updated state management and rendering logic to support the new tab, with proper loading and error handling.
	2.	API Update:
	▪	Introduced a getCoinsPosts method in apps/next/lib/api/index.ts to fetch coin posts from the backend.
	3.	New Backend Route:
	▪	Added a route in packages/api/src/routes/feed.ts for /feed/:tokenAddress/coins, which checks Redis for cached data and fetches relevant user casts.
These changes enhance the application's functionality by allowing users to access coin-related posts.