### PR TITLE
bump array helpers

### DIFF
--- a/packages/circuits/create-post/Nargo.toml
+++ b/packages/circuits/create-post/Nargo.toml
@@ -2,7 +2,8 @@
 name = "main"
 type = "bin"
 authors = ["Kartik Patel"]
-compiler_version = "0.17.0"
+compiler_version = ">=0.30.0"
 
 [dependencies]
 ecrecover = { path = "../ecrecover-noir" }
+mimc = { tag = "v0.1.0", git = "https://github.com/noir-lang/mimc" }

--- a/packages/circuits/create-post/src/main.nr
+++ b/packages/circuits/create-post/src/main.nr
@@ -29,7 +29,7 @@ fn main(
     let recovered_address = ecrecover::ecrecover(pub_key_x, pub_key_y, signature, message_hash);
     assert(address == recovered_address);
 
-    let commitment = std::hash::mimc_bn254([address, balance]);
+    let commitment = mimc::mimc_bn254([address, balance]);
 
     // Check that the input note commitment is in the root
     let new_root = compute_root_from_leaf(commitment, index, note_hash_path);
@@ -39,11 +39,10 @@ fn main(
 }
 
 // Returns the root of the tree from the provided leaf and its hashpath, using mimc hash
-fn compute_root_from_leaf(leaf: Field, index: Field, hash_path: [Field; 13]) -> Field {
-    let n = hash_path.len();
-    let index_bits = index.to_le_bits(n as u32);
+fn compute_root_from_leaf<let N: u32>(leaf: Field, index: Field, hash_path: [Field; N]) -> Field {
+    let index_bits: [u1; N] = index.to_le_bits();
     let mut current = leaf;
-    for i in 0..n {
+    for i in 0..N {
         let path_bit = index_bits[i] as bool;
         let (hash_left, hash_right) = if path_bit {
             (hash_path[i], current)
@@ -51,7 +50,7 @@ fn compute_root_from_leaf(leaf: Field, index: Field, hash_path: [Field; 13]) -> 
             (current, hash_path[i])
         };
 
-        current = std::hash::mimc_bn254([hash_left, hash_right]);
+        current = mimc::mimc_bn254([hash_left, hash_right]);
     }
     current
 }

--- a/packages/circuits/ecrecover-noir/Nargo.toml
+++ b/packages/circuits/ecrecover-noir/Nargo.toml
@@ -1,9 +1,9 @@
 [package]
 authors = ["@colinnielsen"]
-compiler_version = ">=0.19.0"
+compiler_version = ">=0.30.0"
 name = "ecrecover"
 notes = "AMDG"
 type = "lib"
 
 [dependencies]
-array_helpers = { tag = "v0.19.0", git = "https://github.com/colinnielsen/noir-array-helpers" }
+array_helpers = { tag = "v0.30.0", git = "https://github.com/colinnielsen/noir-array-helpers" }

--- a/packages/circuits/submit-hash/Nargo.toml
+++ b/packages/circuits/submit-hash/Nargo.toml
@@ -2,7 +2,8 @@
 name = "main"
 type = "bin"
 authors = ["Kartik Patel"]
-compiler_version = "0.17.0"
+compiler_version = ">=0.30.0"
 
 [dependencies]
 ecrecover = { path = "../ecrecover-noir" }
+mimc = { tag = "v0.1.0", git = "https://github.com/noir-lang/mimc" }

--- a/packages/circuits/submit-hash/src/main.nr
+++ b/packages/circuits/submit-hash/src/main.nr
@@ -23,7 +23,7 @@ fn main(
     let recovered_address = ecrecover::ecrecover(pub_key_x, pub_key_y, signature, message_hash);
     assert(address == recovered_address);
 
-    let commitment = std::hash::mimc_bn254([address, balance]);
+    let commitment = mimc::mimc_bn254([address, balance]);
 
     // Check that the input note commitment is in the root
     let new_root = compute_root_from_leaf(commitment, index, note_hash_path);
@@ -33,11 +33,10 @@ fn main(
 }
 
 // Returns the root of the tree from the provided leaf and its hashpath, using mimc hash
-fn compute_root_from_leaf(leaf: Field, index: Field, hash_path: [Field; 13]) -> Field {
-    let n = hash_path.len();
-    let index_bits = index.to_le_bits(n as u32);
+fn compute_root_from_leaf<let N: u32>(leaf: Field, index: Field, hash_path: [Field; N]) -> Field {
+    let index_bits: [u1; N] = index.to_le_bits();
     let mut current = leaf;
-    for i in 0..n {
+    for i in 0..N {
         let path_bit = index_bits[i] as bool;
         let (hash_left, hash_right) = if path_bit {
             (hash_path[i], current)
@@ -45,7 +44,7 @@ fn compute_root_from_leaf(leaf: Field, index: Field, hash_path: [Field; 13]) -> 
             (current, hash_path[i])
         };
 
-        current = std::hash::mimc_bn254([hash_left, hash_right]);
+        current = mimc::mimc_bn254([hash_left, hash_right]);
     }
     current
 }


### PR DESCRIPTION
The latest version of array helpers fixes vulnerability in ecrecover-noir. Bumped compiler version in create-post and submit-hash. Mimc is moved out of stdlib in the latest version.

Vulnerability in ecrecover - https://gist.github.com/olehmisar/4cfe6128eaac2bfbe1fa8eb46f0116d6